### PR TITLE
Allow provider to indicate if they work for a shipment.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,3 @@ DEPENDENCIES
   simplecov
   spree_shipping_labels!
   sqlite3
-
-BUNDLED WITH
-   1.10.4

--- a/app/models/concerns/spree/shipment_provider/initialization.rb
+++ b/app/models/concerns/spree/shipment_provider/initialization.rb
@@ -20,4 +20,9 @@ module Spree::ShipmentProvider::Initialization
     @package = package
   end
 
+  # Defaults to being available.
+  def available?
+    true
+  end
+
 end

--- a/app/models/spree/calculator/shipping/quoted_for_label.rb
+++ b/app/models/spree/calculator/shipping/quoted_for_label.rb
@@ -29,4 +29,9 @@ class Spree::Calculator::Shipping::QuotedForLabel < Spree::ShippingCalculator
     estimate
   end
 
+  def available? package
+    provider = Spree::ShipmentProvider.find_by name: preferred_provider
+    provider.available? preferred_service_type, package
+  end
+
 end

--- a/app/models/spree/shipment_provider.rb
+++ b/app/models/spree/shipment_provider.rb
@@ -9,6 +9,10 @@ class Spree::ShipmentProvider < Spree::Base
     backend.new(service_type, package_type, shipment).generate_label!
   end
 
+  def available? service_type, package
+    backend.new(service_type, nil, package).available?
+  end
+
   private
 
   def backend

--- a/app/models/spree/shipment_provider/ups.rb
+++ b/app/models/spree/shipment_provider/ups.rb
@@ -29,6 +29,10 @@ class Spree::ShipmentProvider::Ups
     end
   end
 
+  def available?
+    super && !to_location.po_box?
+  end
+
   protected
 
   def config options

--- a/lib/spree/shipping_labels.rb
+++ b/lib/spree/shipping_labels.rb
@@ -1,6 +1,19 @@
 require 'spree_core'
 require 'active_shipping'
 
+class ActiveShipping::Location
+  # Yea, a bit crazy. Borrowed from
+  PO_REGEXP = /^ *((#\d+)|((box|bin)[-. \/\\]?\d+)|(.*p[ \.]? ?(o|0)[-. \/\\]? *-?((box|bin)|b|(#|num)?\d+))|(p(ost)? *(o(ff(ice)?)?)? *((box|bin)|b)? *\d+)|(p *-?\/?(o)? *-?box)|post office box|((box|bin)|b) *(number|num|#)? *\d+|(num|number|#) *\d+)/i
+
+  # Override to try to automatically detect if an address is a P.O. Box
+  def po_box?
+    # Original implementation. Still allow it to be manually set
+    (@address_type == 'po_box') ||
+    (1..3).any? { |i| public_send("address#{i}") =~ PO_REGEXP }
+  end
+
+end
+
 module Spree::ShippingLabels
   # Thrown if a problem occurs when estimating or generating a label
   class Error < StandardError

--- a/spec/misc_spec.rb
+++ b/spec/misc_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe ActiveShipping::Location do
+
+  it 'indicates po box if manually set (stock behavior)' do
+    expect( ActiveShipping::Location.new(address_type: 'po_box').po_box? ).to eq true
+  end
+
+  it 'can detect po boxes' do
+    yes = [
+      # "box" can be substituted for "bin"
+      "#123", "Box 123", "Box-122", "Box122", "HC73 P.O. Box 217",
+      "P O Box125", "P. O. Box", "P.O 123", "P.O. Box 123", "P.O. Box",
+      "P.O.B 123", "P.O.B. 123", "P.O.B.", "P0 Box", "PO 123", "PO Box N",
+      "PO Box", "PO-Box", "POB 123", "POB", "POBOX123", "Po Box", "Post 123",
+      "Post Box 123", "Post Office Box 123", "Post Office Box", "box #123",
+      "box 122", "box 123", "number 123", "p box", "p-o box", "p-o-box",
+      "p.o box", "p.o. box", "p.o.-box", "p.o.b. #123", "p.o.b.", "p/o box",
+      "po #123", "po box 123", "po box", "po num123", "po-box", "pobox",
+      "pobox123", "post office box"
+    ]
+    expect( yes.all? {|t| ActiveShipping::Location.new(address1: t).po_box? }).to eq true
+  end
+
+  it 'cannot be fooled' do
+    no = [
+      "The Postal Road", "Box Hill", "123 Some Street",
+      "Controller's Office", "pollo St.", "123 box canyon rd",
+      "777 Post Oak Blvd", "PSC 477 Box 396", "RR 1 Box 1020"
+    ]
+    expect( no.any? {|t| ActiveShipping::Location.new(address1: t).po_box? }).to eq false
+  end
+
+end


### PR DESCRIPTION
Make UPS not work if the address is a P.O. Box.