### PR TITLE
Enable insurance on labels.

### DIFF
--- a/app/models/concerns/spree/shipment_provider/active_shipping.rb
+++ b/app/models/concerns/spree/shipment_provider/active_shipping.rb
@@ -69,7 +69,8 @@ class Spree::ShipmentProvider < Spree::Base
     def package_for_label
       @package_for_label ||= ::ActiveShipping::Package.new @package.weight_in_oz,
         [@package_type.length, @package_type.width, @package_type.height],
-        units: :imperial, package_type: package_type_code(@package_type.provider_type)
+        units: :imperial, package_type: package_type_code(@package_type.provider_type),
+        value: @package.try(:item_cost).try(:to_s)
     end
 
     def provider_name

--- a/app/models/spree/shipment_provider/stamps.rb
+++ b/app/models/spree/shipment_provider/stamps.rb
@@ -10,7 +10,7 @@ class Spree::ShipmentProvider::Stamps
 
   def generate_label!
     response = io.create_shipment from_location, to_location, package_for_label, [],
-      service: ActiveShipping::Stamps::SERVICE_TYPES.invert[@service_type], add_ons: 'SC-A-HP'
+      service: ActiveShipping::Stamps::SERVICE_TYPES.invert[@service_type], add_ons: ['SC-A-HP', 'SC-A-INS']
     ActiveRecord::Base.transaction do
       @package.update_attributes! tracking: response.tracking_number
       label = @package.label || @package.build_label


### PR DESCRIPTION
This currently only works for Stamps.com as the ActiveShipping support
for UPS doens't include their insurance stuff. It could be added fairly
easily but since they insurance for $100 at least it didn't seem necessary
at this point.

Also insurance is always enabled. We could make this conditional but then
we need to make an interface to configure. Since people will want insurance
more often than not it seems if we are not making it optional we should make
it enabled.