### PR TITLE
Allow insurance to be enabled/disabled.

### DIFF
--- a/app/assets/javascripts/spree/backend/package_type_selector.js.coffee
+++ b/app/assets/javascripts/spree/backend/package_type_selector.js.coffee
@@ -8,6 +8,7 @@ $(document).on 'change', selector, ->
   resource = $_.attr 'data-resource'
   package_type_id = $_.val()
   insurance = $_.attr 'data-insurance'
+  insurace = null if insurance == ''
 
   $.post resource, package_type_id: package_type_id, insurance: insurance
     .fail ->

--- a/app/controllers/spree/admin/labels_controller.rb
+++ b/app/controllers/spree/admin/labels_controller.rb
@@ -25,9 +25,15 @@ class Spree::Admin::LabelsController < Spree::Admin::BaseController
     # If insurance is provided and it is not 0 then update it also.
     insurance = params[:insurance]
     insurance = nil if insurance.to_f == 0.0
-    shipment.insurance = insurance if insurance.present?
+    if insurance.present?
+      shipment.insurance_enabled = true
+      shipment.insurance = insurance
+    else
+      shipment.insurance_enabled = false
+    end
 
-    shipment.generate_label! if shipment.package_type_id_changed? || shipment.insurance_changed?
+    shipment.generate_label! if
+      shipment.package_type_id_changed? || shipment.insurance_changed? || shipment.insurance_enabled_changed?
 
     render json: shipment.label, only: %i(cost)
   end

--- a/app/helpers/spree/admin/shipping_label_helper.rb
+++ b/app/helpers/spree/admin/shipping_label_helper.rb
@@ -18,7 +18,7 @@ module Spree::Admin::ShippingLabelHelper
       id: nil, class: 'package-type-selector', data: {
         resource: admin_label_path(shipment_id: shipment.id),
         cost: shipment.label.try(:cost), order: shipment.order_id,
-        shipment: shipment.id
+        shipment: shipment.id, insurance: (shipment.insurance_enabled? ? shipment.insurance : nil)
       }
   end
 

--- a/app/models/concerns/spree/shipment_provider/active_shipping.rb
+++ b/app/models/concerns/spree/shipment_provider/active_shipping.rb
@@ -70,6 +70,7 @@ class Spree::ShipmentProvider < Spree::Base
       return if defined? @package_for_label
       insurance = @package.try(:insurance).try :to_s
       insurance = nil if insurance == '0'
+      insurance = nil unless @package.try(:insurance_enabled?)
       @package_for_label = ::ActiveShipping::Package.new @package.weight_in_oz,
         [@package_type.length, @package_type.width, @package_type.height],
         units: :imperial, package_type: package_type_code(@package_type.provider_type),

--- a/app/models/spree/shipment_provider/stamps.rb
+++ b/app/models/spree/shipment_provider/stamps.rb
@@ -9,8 +9,13 @@ class Spree::ShipmentProvider::Stamps
   Spree::ShipmentProvider.backends << self
 
   def generate_label!
+    add_ons = ['SC-A-HP'] # Make the postage cost hidden on the printout
+
+    # Only assign the insurance add-on IF the package has insurable value
+    add_ons << 'SC-A-INS' if package_for_label.value
+
     response = io.create_shipment from_location, to_location, package_for_label, [],
-      service: ActiveShipping::Stamps::SERVICE_TYPES.invert[@service_type], add_ons: ['SC-A-HP', 'SC-A-INS']
+      service: ActiveShipping::Stamps::SERVICE_TYPES.invert[@service_type], add_ons: add_ons
     ActiveRecord::Base.transaction do
       @package.update_attributes! tracking: response.tracking_number
       label = @package.label || @package.build_label

--- a/db/migrate/20151202131300_insurance_enabled.rb
+++ b/db/migrate/20151202131300_insurance_enabled.rb
@@ -1,0 +1,10 @@
+class InsuranceEnabled < ActiveRecord::Migration
+
+  def change
+    add_column :spree_shipments, :insurance_enabled, :boolean, null: false, default: false
+    say_with_time 'enabling insurance on historical shipped shipments' do
+      Spree::Shipment.shipped.update_all insurance_enabled: true
+    end
+  end
+
+end

--- a/spec/models/concerns/spree/shipment_provider/active_shipping_spec.rb
+++ b/spec/models/concerns/spree/shipment_provider/active_shipping_spec.rb
@@ -52,16 +52,29 @@ describe Spree::ShipmentProvider::ActiveShipping do
       expect( pkg.inches(:height) ).to eq 2
     end
 
-    it 'from spree shipment' do
-      shipment = create :shipment, order: create(:order_with_line_items), state: 'ready', insurance: 5.25
-      shipment.order.line_items.first.variant.update_attribute :weight, 8.2
-      provider = klass.new 'USPS First Class', package_type, shipment
-      pkg = provider.send :package_for_label
-      expect( pkg.ounces.to_f ).to eq 8.2
-      expect( pkg.inches(:length) ).to eq 12.5
-      expect( pkg.inches(:width) ).to eq 9
-      expect( pkg.inches(:height) ).to eq 2
-      expect( pkg.value ).to eq 525
+    describe 'from spree shipment' do
+      before do
+        @shipment = create :shipment, order: create(:order_with_line_items), state: 'ready', insurance: 5.25
+        @shipment.order.line_items.first.variant.update_attribute :weight, 8.2
+        @provider = klass.new 'USPS First Class', package_type, @shipment
+      end
+
+      it 'with insurance enabled' do
+        @shipment.update_attributes! insurance_enabled: true
+        pkg = @provider.send :package_for_label
+
+        expect( pkg.ounces.to_f ).to eq 8.2
+        expect( pkg.inches(:length) ).to eq 12.5
+        expect( pkg.inches(:width) ).to eq 9
+        expect( pkg.inches(:height) ).to eq 2
+        expect( pkg.value ).to eq 525
+      end
+
+      it 'with no insurance' do
+        @shipment.update_attributes! insurance_enabled: false
+        pkg = @provider.send :package_for_label
+        expect( pkg.value ).to eq nil
+      end
     end
   end
 


### PR DESCRIPTION
At the model level we have two attributes. The insurance amount as well as
if insurance is enabled/disabled. This allows us to disable the insurance but
still keep the old value of the insurance should we decide to enable it again.

Tests are a bit light for two reasons:

* It interacts with 3rd party services and mocks/stubs would have dubious value.
* It's only a fragment of the UI that is fully implemented in the application.